### PR TITLE
Add custom http root

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -71,6 +71,9 @@ OCS_DEBUG_ZPAGES
 OCS_HTTP_ADDR
 : Address to bind http server, defaults to `0.0.0.0:9110`
 
+OCS_HTTP_ROOT
+: Root path of http server, defaults to `/`
+
 ##### Health
 
 OCS_DEBUG_ADDR
@@ -125,6 +128,9 @@ If you prefer to configure the service with commandline flags you can see the av
 
 --http-addr
 : Address to bind http server, defaults to `0.0.0.0:9110`
+
+--http-root
+: Root path of http server, defaults to `/`
 
 ##### Health
 

--- a/pkg/command/server.go
+++ b/pkg/command/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"strings"
 	"time"
 
 	"contrib.go.opencensus.io/exporter/jaeger"
@@ -28,6 +29,13 @@ func Server(cfg *config.Config) cli.Command {
 		Name:  "server",
 		Usage: "Start integrated server",
 		Flags: flagset.ServerWithConfig(cfg),
+		Before: func(c *cli.Context) error {
+			if cfg.HTTP.Root != "/" {
+				cfg.HTTP.Root = strings.TrimSuffix(cfg.HTTP.Root, "/")
+			}
+
+			return nil
+		},
 		Action: func(c *cli.Context) error {
 			logger := NewLogger(cfg)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,6 +18,7 @@ type Debug struct {
 // HTTP defines the available http configuration.
 type HTTP struct {
 	Addr string
+	Root string
 }
 
 // Tracing defines the available tracing configuration.

--- a/pkg/flagset/flagset.go
+++ b/pkg/flagset/flagset.go
@@ -120,5 +120,12 @@ func ServerWithConfig(cfg *config.Config) []cli.Flag {
 			EnvVar:      "OCS_HTTP_ADDR",
 			Destination: &cfg.HTTP.Addr,
 		},
+		&cli.StringFlag{
+			Name:        "http-root",
+			Value:       "/",
+			Usage:       "Root path of http server",
+			EnvVar:      "OCS_HTTP_ROOT",
+			Destination: &cfg.HTTP.Root,
+		},
 	}
 }

--- a/pkg/service/v0/service.go
+++ b/pkg/service/v0/service.go
@@ -25,7 +25,9 @@ func NewService(opts ...Option) Service {
 		mux:    m,
 	}
 
-	m.HandleFunc("/", svc.Dummy)
+	m.Route(options.Config.HTTP.Root, func(r chi.Router) {
+		r.Get("/", svc.Dummy)
+	})
 
 	return svc
 }
@@ -43,5 +45,8 @@ func (g Ocs) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // Dummy implements the Service interface.
 func (g Ocs) Dummy(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(http.StatusOK)
+
+	w.Write([]byte(http.StatusText(http.StatusOK)))
 }


### PR DESCRIPTION
Now we are able to let this service run on a different root path.

