### PR TITLE
Use a single GRPC new client instance

### DIFF
--- a/changelog/unreleased/fix-file-descriptor-leak.md
+++ b/changelog/unreleased/fix-file-descriptor-leak.md
@@ -1,0 +1,7 @@
+Bugfix: Fix file descriptor leak
+
+Only use a single instance of go-micro's GRPC client as it already
+does connection pooling. This prevents connection and file descriptor leaks.
+
+https://github.com/owncloud/ocis-accounts/issues/79
+https://github.com/owncloud/ocis-ocs/pull/29

--- a/pkg/service/v0/service.go
+++ b/pkg/service/v0/service.go
@@ -16,6 +16,8 @@ import (
 	"github.com/owncloud/ocis-pkg/v2/log"
 )
 
+var defaultClient = grpc.NewClient()
+
 // Service defines the extension handlers.
 type Service interface {
 	ServeHTTP(http.ResponseWriter, *http.Request)
@@ -100,9 +102,9 @@ func (o Ocs) NotFound(w http.ResponseWriter, r *http.Request) {
 }
 
 func (o Ocs) getAccountService() accounts.AccountsService {
-	return accounts.NewAccountsService("com.owncloud.api.accounts", grpc.NewClient())
+	return accounts.NewAccountsService("com.owncloud.api.accounts", defaultClient)
 }
 
 func (o Ocs) getGroupsService() accounts.GroupsService {
-	return accounts.NewGroupsService("com.owncloud.api.accounts", grpc.NewClient())
+	return accounts.NewGroupsService("com.owncloud.api.accounts", defaultClient)
 }


### PR DESCRIPTION
The client is already using a connection pool, so we should not
instantiate it multiple times as it causes connections to stay open and
makes file descriptors leak.

Fixes https://github.com/owncloud/ocis-accounts/issues/79
