### PR TITLE
Use opaque ID of a user for signing keys

### DIFF
--- a/changelog/unreleased/signing-keys-opaqueid
+++ b/changelog/unreleased/signing-keys-opaqueid
@@ -1,0 +1,8 @@
+Bugfix: Use opaque ID of a user for signing keys
+
+OCIS switched from user the user's opaque ID (UUID) everywhere,
+so to keep compatible we have adjusted the signing keys endpoint
+to also use the UUID when storing and generating the keys.
+
+https://github.com/owncloud/ocis/issues/436
+https://github.com/owncloud/ocis-ocs/pull/32


### PR DESCRIPTION
OCIS switched from user the user's opaque ID (UUID) everywhere,
so to keep compatible we have adjusted the signing keys endpoint
to also use the UUID when storing and generating the keys.

Fixes https://github.com/owncloud/ocis/issues/436

Doesn't work yet:
```
2020-08-07T11:04:23+02:00 ERR Account not found query="preferred_name eq '4c510ada-c86b-4815-8820-42cdf82c3d51'" service=proxy
2020-08-07T11:04:23+02:00 ERR could not create account error="{\"id\":\"com.owncloud.api.accounts\",\"code\":400,\"detail\":\"preferred_name '4c510ada-c86b-4815-8820-42cdf82c3d51' must be at least the local part of an email\",\"status\":\"Bad Request\"}" account={"accountEnabled":true,"creationType":"LocalAccount","onPremisesSamAccountName":"4c510ada-c86b-4815-8820-42cdf82c3d51","preferredName":"4c510ada-c86b-4815-8820-42cdf82c3d51"} service=proxy
2020-08-07T11:04:23+02:00 ERR Account not found query="preferred_name eq '4c510ada-c86b-4815-8820-42cdf82c3d51'" service=proxy
2020-08-07T11:04:23+02:00 ERR could not create account error="{\"id\":\"com.owncloud.api.accounts\",\"code\":400,\"detail\":\"preferred_name '4c510ada-c86b-4815-8820-42cdf82c3d51' must be at least the local part of an email\",\"status\":\"Bad Request\"}" account={"accountEnabled":true,"creationType":"LocalAccount","onPremisesSamAccountName":"4c510ada-c86b-4815-8820-42cdf82c3d51","preferredName":"4c510ada-c86b-4815-8820-42cdf82c3d51"} service=proxy
2020-08-07 11:04:23.994031 I | http: superfluous response.WriteHeader call from github.com/owncloud/ocis-proxy/pkg/middleware.AccountUUID.func1.1 (account_uuid.go:125)

```