### PR TITLE
fix ocs resonse format

### DIFF
--- a/changelog/unreleased/ocs-response-format.md
+++ b/changelog/unreleased/ocs-response-format.md
@@ -1,0 +1,8 @@
+Bugfix: Add the top level response structure to json responses 
+
+Probably during moving the ocs code into the ocis-ocs repo the response format was changed.
+This change adds the top level response to json responses. Doing that the reponse should be compatible to the responses from OC10.
+
+https://github.com/owncloud/product/issues/181
+https://github.com/owncloud/product/issues/181#issuecomment-683604168
+


### PR DESCRIPTION
This should fix this https://github.com/owncloud/product/issues/181#issuecomment-683604168.
Adds the missing top level response structure
```json
{
  "ocs": {
   ...
  }
}
```
The json response looks like this now
```json
{
  "ocs": {
    "meta": {
      "status": "ok",
      "statuscode": 100,
      "message": "OK"
    },
    "data": {
      "enabled": "true",
      "id": "4c510ada-c86b-4815-8820-42cdf82c3d51",
      "username": "einstein",
      "displayname": "Albert Einstein",
      "email": "einstein@example.org",
      "quota": {
        "free": 2840756224000,
        "used": 5059416668,
        "total": 2845815640668,
        "relative": 0.18,
        "definition": "default"
      },
      "uidnumber": 20000,
      "gidnumber": 30000
    }
  }
}
```

Before:
```json
{
  "meta": {
    "status": "ok",
    "statuscode": 100,
    "message": "OK"
  },
  "data": {
    "enabled": "true",
    "id": "4c510ada-c86b-4815-8820-42cdf82c3d51",
    "username": "einstein",
    "displayname": "Albert Einstein",
    "email": "einstein@example.org",
    "quota": {
      "free": 2840756224000,
      "used": 5059416668,
      "total": 2845815640668,
      "relative": 0.18,
      "definition": "default"
    },
    "uidnumber": 20000,
    "gidnumber": 30000
  }
}
```